### PR TITLE
handle diplaying block groups when percent of meters is <50%

### DIFF
--- a/coop/rdof/rdof_coast_eg.html
+++ b/coop/rdof/rdof_coast_eg.html
@@ -135,31 +135,14 @@
             url: blockGroupsUrl
           },
           'source-layer': blockGroupsSourceLayer,
-          filter: ['>', blockGroundPctAttr, 50],
+          filter: ['>', blockGroundPctAttr, 0],
           paint: {
-            'fill-color': blockGroupFill,
-            'fill-opacity': 0.4
-          },
-          layout: {
-            visibility: 'visible'
-          }
-        });
-
-        map.addLayer({
-          id: 'blockGroups2',
-          type: 'fill',
-          source: {
-            type: 'vector',
-            url: blockGroupsUrl
-          },
-          'source-layer': blockGroupsSourceLayer,
-          filter: [
-            'all',
-            ['<', blockGroundPctAttr, 50],
-            ['>', blockGroundPctAttr, 0]
-          ],
-          paint: {
-            'fill-color': blockGroup2Fill,
+            'fill-color': [
+              'case',
+              ['<', ['to-number', ['get', blockGroundPctAttr]], 50],
+              blockGroup2Fill,
+              blockGroupFill
+            ],
             'fill-opacity': 0.4
           },
           layout: {
@@ -177,31 +160,14 @@
             url: blockGroupsUrl
           },
           'source-layer': blockGroupsSourceLayer,
-          filter: ['>', blockGroundPctAttr, 50],
+          filter: ['>', blockGroundPctAttr, 0],
           paint: {
-            'line-color': blockGroupFill,
-            'line-width': 3
-          },
-          layout: {
-            visibility: 'visible'
-          }
-        });
-
-        map.addLayer({
-          id: 'blockGroupsLines2',
-          type: 'line',
-          source: {
-            type: 'vector',
-            url: blockGroupsUrl
-          },
-          'source-layer': blockGroupsSourceLayer,
-          filter: [
-            'all',
-            ['<', blockGroundPctAttr, 50],
-            ['>', blockGroundPctAttr, 0]
-          ],
-          paint: {
-            'line-color': blockGroup2Fill,
+            'line-color': [
+              'case',
+              ['<', ['to-number', ['get', blockGroundPctAttr]], 50],
+              blockGroup2Fill,
+              blockGroupFill
+            ],
             'line-width': 3
           },
           layout: {
@@ -310,49 +276,14 @@
               id: 'blockGroupsText',
               type: 'symbol',
               source: 'blockGroupsText',
-              filter: ['>', blockGroundPctAttr, 50],
+              filter: ['>', blockGroundPctAttr, 0],
               paint: {
-                'text-color': blockGroupBorder
-              },
-              layout: {
-                'text-field': [
-                  'number-format',
-                  ['get', 'fcc_amt'],
-                  { currency: 'USD' }
-                ],
-                'symbol-placement': 'point',
-                'text-allow-overlap': true,
-                'text-justify': 'center',
-                'text-padding': 4,
-                'text-rotation-alignment': 'viewport',
-                'text-font': [
-                  'literal',
-                  ['DIN Offc Pro Bold', 'Arial Unicode MS Regular']
-                ],
-                'text-size': {
-                  base: 0,
-                  stops: [
-                    [10, 12],
-                    [12, 14],
-                    [14, 20],
-                    [15, 22],
-                    [16, 28]
-                  ]
-                }
-              }
-            });
-
-            map.addLayer({
-              id: 'blockGroupsText2',
-              type: 'symbol',
-              source: 'blockGroupsText',
-              filter: [
-                'all',
-                ['<', blockGroundPctAttr, 50],
-                ['>', blockGroundPctAttr, 0]
-              ],
-              paint: {
-                'text-color': blockGroup2Fill
+                'text-color': [
+                  'case',
+                  ['<', ['to-number', ['get', blockGroundPctAttr]], 50],
+                  blockGroup2Fill,
+                  blockGroupBorder
+                ]
               },
               layout: {
                 'text-field': [
@@ -422,17 +353,6 @@
                 'visibility',
                 'none'
               );
-              map.setLayoutProperty(
-                `${clickedLayer}Lines2`,
-                'visibility',
-                'none'
-              );
-              map.setLayoutProperty(
-                `${clickedLayer}Text2`,
-                'visibility',
-                'none'
-              );
-              map.setLayoutProperty(`${clickedLayer}2`, 'visibility', 'none');
             }
           } else {
             this.className = 'active';
@@ -446,21 +366,6 @@
             if (clickedLayer === 'blockGroups') {
               map.setLayoutProperty(
                 `${clickedLayer}Lines`,
-                'visibility',
-                'visible'
-              );
-              map.setLayoutProperty(
-                `${clickedLayer}Lines2`,
-                'visibility',
-                'visible'
-              );
-              map.setLayoutProperty(
-                `${clickedLayer}Text2`,
-                'visibility',
-                'visible'
-              );
-              map.setLayoutProperty(
-                `${clickedLayer}2`,
                 'visibility',
                 'visible'
               );

--- a/coop/rdof/rdof_coast_eg.html
+++ b/coop/rdof/rdof_coast_eg.html
@@ -91,6 +91,8 @@
       const blockFill = '#FFA500';
       const blockGroupFill = '#008000';
       const blockGroupBorder = '#044D04';
+      const blockGroup2Fill = '#0000FF';
+      const blockGroup2Border = '#0000FF';
       const meters = '#808080';
       const blockBorder = '#000000';
       /**************************
@@ -157,7 +159,7 @@
             ['>', blockGroundPctAttr, 0]
           ],
           paint: {
-            'fill-color': 'blue',
+            'fill-color': blockGroup2Fill,
             'fill-opacity': 0.4
           },
           layout: {
@@ -199,7 +201,7 @@
             ['>', blockGroundPctAttr, 0]
           ],
           paint: {
-            'line-color': 'blue',
+            'line-color': blockGroup2Fill,
             'line-width': 3
           },
           layout: {
@@ -350,7 +352,7 @@
                 ['>', blockGroundPctAttr, 0]
               ],
               paint: {
-                'text-color': 'blue'
+                'text-color': blockGroup2Fill
               },
               layout: {
                 'text-field': [

--- a/coop/rdof/rdof_coast_eg.html
+++ b/coop/rdof/rdof_coast_eg.html
@@ -143,21 +143,22 @@
           }
         });
 
-        // blocks layer
-
         map.addLayer({
-          id: 'blocks',
+          id: 'blockGroups2',
           type: 'fill',
           source: {
             type: 'vector',
-            url: blocksUrl
+            url: blockGroupsUrl
           },
-          'source-layer': blocksSourceLayer,
-          filter: ['>', blockMetersAttr, 0],
+          'source-layer': blockGroupsSourceLayer,
+          filter: [
+            'all',
+            ['<', blockGroundPctAttr, 50],
+            ['>', blockGroundPctAttr, 0]
+          ],
           paint: {
-            'fill-color': blockFill,
-            'fill-opacity': 0.9,
-            'fill-outline-color': blockBorder
+            'fill-color': 'blue',
+            'fill-opacity': 0.4
           },
           layout: {
             visibility: 'visible'
@@ -178,6 +179,49 @@
           paint: {
             'line-color': blockGroupFill,
             'line-width': 3
+          },
+          layout: {
+            visibility: 'visible'
+          }
+        });
+
+        map.addLayer({
+          id: 'blockGroupsLines2',
+          type: 'line',
+          source: {
+            type: 'vector',
+            url: blockGroupsUrl
+          },
+          'source-layer': blockGroupsSourceLayer,
+          filter: [
+            'all',
+            ['<', blockGroundPctAttr, 50],
+            ['>', blockGroundPctAttr, 0]
+          ],
+          paint: {
+            'line-color': 'blue',
+            'line-width': 3
+          },
+          layout: {
+            visibility: 'visible'
+          }
+        });
+
+        // blocks layer
+
+        map.addLayer({
+          id: 'blocks',
+          type: 'fill',
+          source: {
+            type: 'vector',
+            url: blocksUrl
+          },
+          'source-layer': blocksSourceLayer,
+          filter: ['>', blockMetersAttr, 0],
+          paint: {
+            'fill-color': blockFill,
+            'fill-opacity': 0.9,
+            'fill-outline-color': blockBorder
           },
           layout: {
             visibility: 'visible'
@@ -295,6 +339,46 @@
                 }
               }
             });
+
+            map.addLayer({
+              id: 'blockGroupsText2',
+              type: 'symbol',
+              source: 'blockGroupsText',
+              filter: [
+                'all',
+                ['<', blockGroundPctAttr, 50],
+                ['>', blockGroundPctAttr, 0]
+              ],
+              paint: {
+                'text-color': 'blue'
+              },
+              layout: {
+                'text-field': [
+                  'number-format',
+                  ['get', 'fcc_amt'],
+                  { currency: 'USD' }
+                ],
+                'symbol-placement': 'point',
+                'text-allow-overlap': true,
+                'text-justify': 'center',
+                'text-padding': 4,
+                'text-rotation-alignment': 'viewport',
+                'text-font': [
+                  'literal',
+                  ['DIN Offc Pro Bold', 'Arial Unicode MS Regular']
+                ],
+                'text-size': {
+                  base: 0,
+                  stops: [
+                    [10, 12],
+                    [12, 14],
+                    [14, 20],
+                    [15, 22],
+                    [16, 28]
+                  ]
+                }
+              }
+            });
           });
       });
 
@@ -330,12 +414,24 @@
                 'visibility',
                 'none'
               );
-            if (clickedLayer === 'blockGroups')
+            if (clickedLayer === 'blockGroups') {
               map.setLayoutProperty(
                 `${clickedLayer}Lines`,
                 'visibility',
                 'none'
               );
+              map.setLayoutProperty(
+                `${clickedLayer}Lines2`,
+                'visibility',
+                'none'
+              );
+              map.setLayoutProperty(
+                `${clickedLayer}Text2`,
+                'visibility',
+                'none'
+              );
+              map.setLayoutProperty(`${clickedLayer}2`, 'visibility', 'none');
+            }
           } else {
             this.className = 'active';
             map.setLayoutProperty(clickedLayer, 'visibility', 'visible');
@@ -345,12 +441,28 @@
                 'visibility',
                 'visible'
               );
-            if (clickedLayer === 'blockGroups')
+            if (clickedLayer === 'blockGroups') {
               map.setLayoutProperty(
                 `${clickedLayer}Lines`,
                 'visibility',
                 'visible'
               );
+              map.setLayoutProperty(
+                `${clickedLayer}Lines2`,
+                'visibility',
+                'visible'
+              );
+              map.setLayoutProperty(
+                `${clickedLayer}Text2`,
+                'visibility',
+                'visible'
+              );
+              map.setLayoutProperty(
+                `${clickedLayer}2`,
+                'visibility',
+                'visible'
+              );
+            }
           }
         };
 


### PR DESCRIPTION
@feomike - Need to clean this up (variables and try to make it work with expressions) but wanted to at least show the screenshot. __ALL__ the block groups, blue and green, currently toggle together.

![rdof-demo](https://user-images.githubusercontent.com/2932572/78028944-cd1a5900-732d-11ea-9f65-7e751a9fb8ab.png)