### PR TITLE
highlight partial, as defined by the FCC, blocks differently

### DIFF
--- a/coop/rdof/blockGroups.html
+++ b/coop/rdof/blockGroups.html
@@ -260,6 +260,7 @@
 
       // colors
       const blockFill = 'orange';
+      const partialBlockFill = 'red';
       const blockGroupFill = 'green';
       const blockGroupBorder = 'darkgreen';
       const blockGroup2Fill = 'blue';
@@ -559,7 +560,12 @@
                   'source-layer': blocksSourceLayer,
                   filter: ['>=', metersAttribute, 0],
                   paint: {
-                    'fill-color': blockFill,
+                    'fill-color': [
+                      'case',
+                      ['==', ['to-number', ['get', 'partial']], 0],
+                      blockFill,
+                      partialBlockFill,
+                    ],
                     'fill-opacity': [
                       'case',
                       ['==', ['to-number', ['get', metersAttribute]], 0],

--- a/coop/rdof/index.html
+++ b/coop/rdof/index.html
@@ -172,6 +172,7 @@
       let maxZoom = 15;
       // colors
       const blockFill = '#FFA500';
+      const partialBlockFill = '#FF0000';
       const blockGroupFill = '#008000';
       const blockGroupBorder = '#044D04';
       const blockGroup2Fill = '#0000FF';
@@ -757,7 +758,12 @@
                   'source-layer': blocksSourceLayer,
                   filter: ['>=', blockMetersAttr, 0],
                   paint: {
-                    'fill-color': blockFill,
+                    'fill-color': [
+                      'case',
+                      ['==', ['to-number', ['get', 'partial']], 0],
+                      blockFill,
+                      partialBlockFill,
+                    ],
                     'fill-opacity': [
                       'case',
                       ['==', ['to-number', ['get', blockMetersAttr]], 0],


### PR DESCRIPTION
### 🚨  We should merge #311 after this. 🚨

This will color partial blocks red at the moment. Some inline comments below to let you know where you can change that to another color.